### PR TITLE
Update README.md to use scipy misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ from vg_beat_detectors import FastNVG
 # import packages used in this example
 import numpy as np
 import matplotlib.pyplot as plt
-from scipy.datasets import electrocardiogram
+from scipy.misc import electrocardiogram
 
 # generate some ECG signal
 ecg = electrocardiogram() # sampling frequency of this excerpt is 360Hz


### PR DESCRIPTION
Originally, the working example in the readme used imported 'electrocardiogram' from 'scipy.datasets', but I think this should have been imported from 'scipy.misc'. I've changed the readme accordingly.

See: https://docs.scipy.org/doc/scipy/reference/generated/scipy.misc.electrocardiogram.html#scipy-misc-electrocardiogram